### PR TITLE
chore: remove boundaries from docstring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ Savitzky-Golay parameters. windowSize should be odd; polynomial is the degree of
 
 Factor to multiply the calculated height (usually 2).
 
-#### boundaries=false
-
-Return also the inflection points of the peaks
-
 #### derivativeThreshold=0
 
 Filters based on the amplitude of the first derivative

--- a/src/gsd.js
+++ b/src/gsd.js
@@ -17,7 +17,6 @@ import SG from 'ml-savitzky-golay-generalized';
  * @param {boolean} [options.realTopDetection = false] - Use a quadratic optimizations with the peak and its 3 closest neighbors
  * to determine the true x,y values of the peak?
  * @param {number} [options.heightFactor = 0] - Factor to multiply the calculated height (usually 2)
- * @param {boolean} [options.boundaries = false] - Return also the inflection points of the peaks
  * @param {number} [options.derivativeThreshold = -1] - Filters based on the amplitude of the first derivative
  * @return {Array<object>}
  */


### PR DESCRIPTION
- this option was removed in https://github.com/mljs/global-spectral-deconvolution/commit/401d16c51eb032b8405ad7a08bf26d60024b261f