### PR TITLE
feat!: change peak shape structure

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -9,8 +9,7 @@ import { writeFileSync } from 'fs';
 import { join } from 'path';
 
 import { generateSpectrum } from 'spectrum-generator';
-
-import { DataType, gsd, optimizePeaks } from '../src';
+import { gsd, optimizePeaks } from '../src';
 
 const peaks = [
   { x: -0.1, y: 0.2, width: 0.3 },
@@ -31,7 +30,7 @@ let peakList = gsd(original, {
   realTopDetection: false,
   smoothY: false,
   heightFactor: 1,
-  shape: { kind: 'gaussian', width: 0 },
+  shape: { kind: 'gaussian' },
 });
 
 let optimizedPeaks = optimizePeaks(original, peakList);

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "cheminfo-build": "^1.1.11",
     "eslint": "^8.1.0",
     "eslint-config-cheminfo-typescript": "^10.2.2",
+    "eslint-plugin-jest": "^25.2.4",
     "esm": "^3.2.25",
     "jest": "^27.3.1",
     "jest-matcher-deep-close-to": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "xy-parser": "^3.2.0"
   },
   "dependencies": {
-    "cheminfo-types": "^0.7.0",
-    "ml-peak-shape-generator": "^2.0.2",
+    "cheminfo-types": "^0.8.0",
+    "ml-peak-shape-generator": "^3.0.1",
     "ml-savitzky-golay-generalized": "2.0.3",
     "ml-spectra-fitting": "^2.0.0",
     "ml-spectra-processing": "^6.8.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "cheminfo-types": "^0.8.0",
-    "ml-peak-shape-generator": "^3.0.1",
+    "ml-peak-shape-generator": "^3.0.2",
     "ml-savitzky-golay-generalized": "2.0.3",
     "ml-spectra-fitting": "^3.0.0",
     "ml-spectra-processing": "^6.8.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "nodemon": "^2.0.14",
     "prettier": "^2.4.1",
     "rimraf": "^3.0.2",
-    "spectrum-generator": "^5.4.1",
+    "spectrum-generator": "^6.0.0",
     "ts-jest": "^27.0.7",
     "typescript": "^4.4.4",
     "xy-parser": "^3.2.0"
@@ -81,7 +81,7 @@
     "cheminfo-types": "^0.8.0",
     "ml-peak-shape-generator": "^3.0.1",
     "ml-savitzky-golay-generalized": "2.0.3",
-    "ml-spectra-fitting": "^2.0.0",
+    "ml-spectra-fitting": "^3.0.0",
     "ml-spectra-processing": "^6.8.0"
   }
 }

--- a/src/__tests__/bigLowS2NSpectrum.test.ts
+++ b/src/__tests__/bigLowS2NSpectrum.test.ts
@@ -1,7 +1,3 @@
-/**
- * Created by acastillo on 2/2/16.
- */
-
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -18,11 +14,14 @@ describe('Global spectra deconvolution NMR spectra', () => {
       {
         noiseLevel: 57000.21889405926, // 1049200.537996172/2,
         minMaxRatio: 0.01,
-        broadRatio: 0.0025,
         sgOptions: { windowSize: 13, polynomial: 3 },
       },
     );
-    pp = joinBroadPeaks(pp, { width: 0.25 });
+
+    pp = joinBroadPeaks({ x: spectrum[0], y: spectrum[1] }, pp, {
+      broadRatio: 0.0025,
+      sgOptions: { windowSize: 13, polynomial: 3 },
+    });
 
     expect(pp).toHaveLength(91);
   });

--- a/src/__tests__/broadNMR.test.ts
+++ b/src/__tests__/broadNMR.test.ts
@@ -14,21 +14,30 @@ describe('Global spectra deconvolution NMR spectra', () => {
       {
         noiseLevel: 1049200.537996172 / 2,
         minMaxRatio: 0.01,
-        broadRatio: 0.0025,
         sgOptions: {
           windowSize: 9,
           polynomial: 3,
         },
       },
     );
-    const newResult = joinBroadPeaks(result, {
-      width: 0.25,
-      shape: { kind: 'lorentzian', width: 0 },
-    });
+
+    const newResult = joinBroadPeaks(
+      { x: spectrum[0], y: spectrum[1] },
+      result,
+      {
+        width: 0.25,
+        broadRatio: 0.0025,
+        shape: { kind: 'lorentzian' },
+        sgOptions: {
+          windowSize: 9,
+          polynomial: 3,
+        },
+      },
+    );
     expect(newResult).toHaveLength(14);
     newResult.forEach((peak) => {
       if (Math.abs(peak.x - 4.31) < 0.01) {
-        expect(peak.shape.width).toBeCloseTo(0.39, 2);
+        expect(peak.width).toBeCloseTo(0.39, 2);
       }
     });
   });

--- a/src/__tests__/infraRed.test.ts
+++ b/src/__tests__/infraRed.test.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from 'fs';
-
-import { DataType, gsd } from '../gsd';
+import type { DataXY } from 'cheminfo-types';
+import { gsd } from '../gsd';
 
 describe('Global spectra deconvolution Infrared spectra', () => {
   // Test case obtained from Pag 443, Chap 8.
   it('Should get the correct result', () => {
-    let spectrum: DataType = JSON.parse(
+    let spectrum: DataXY = JSON.parse(
       readFileSync(`${__dirname}/data/infraRed.json`, 'utf-8'),
     );
     gsd(spectrum, {

--- a/src/__tests__/infraRed.test.ts
+++ b/src/__tests__/infraRed.test.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from 'fs';
+
 import type { DataXY } from 'cheminfo-types';
+
 import { gsd } from '../gsd';
 
 describe('Global spectra deconvolution Infrared spectra', () => {

--- a/src/__tests__/massPeakPicking.test.ts
+++ b/src/__tests__/massPeakPicking.test.ts
@@ -1,10 +1,9 @@
 import CC from 'chemcalc';
+import type { DataXY } from 'cheminfo-types';
+import { Gaussian } from 'ml-peak-shape-generator';
 import Stat from 'ml-stat';
 
-import type { DataXY } from 'cheminfo-types';
 import { gsd, optimizePeaks } from '..';
-
-import { Gaussian } from 'ml-peak-shape-generator'
 
 let spectrum = CC.analyseMF('Cl2.Br2', {
   isotopomers: 'arrayXXYY',

--- a/src/__tests__/massPeakPicking.test.ts
+++ b/src/__tests__/massPeakPicking.test.ts
@@ -1,14 +1,17 @@
 import CC from 'chemcalc';
 import Stat from 'ml-stat';
 
-import { DataType, gsd, optimizePeaks } from '..';
+import type { DataXY } from 'cheminfo-types';
+import { gsd, optimizePeaks } from '..';
+
+import { Gaussian } from 'ml-peak-shape-generator'
 
 let spectrum = CC.analyseMF('Cl2.Br2', {
   isotopomers: 'arrayXXYY',
   fwhm: 0.01,
   gaussianWidth: 11,
 });
-let xy: DataType = spectrum.arrayXXYY;
+let xy: DataXY = spectrum.arrayXXYY;
 let x: number[] = xy[0];
 let y: number[] = xy[1];
 let max = Stat.array.max(y);
@@ -30,7 +33,6 @@ describe('Check the peak picking of a simulated mass spectrum', () => {
       {
         noiseLevel: noiseLevel,
         minMaxRatio: 0,
-        broadRatio: 0,
         smoothY: false,
         realTopDetection: true,
       },
@@ -39,31 +41,31 @@ describe('Check the peak picking of a simulated mass spectrum', () => {
       factorWidth: 4,
       shape: {
         kind: 'gaussian',
-        width: 0,
       },
     });
     expect(result[0].x).toBeCloseTo(69.938, 1);
     expect(result[0].y).toBeCloseTo(max, 2);
-    expect(result[0].shape.width).toBeCloseTo(0.01, 4);
+    expect(result[0].fwhm).toBeCloseTo(0.01, 4);
+    expect(result[0].width).toBeCloseTo(Gaussian.fwhmToWidth(0.01), 4);
 
     expect(result[1].x).toBeCloseTo(71.935, 2);
     expect(result[1].y).toBeCloseTo((63.99155 * max) / 100, 3);
-    expect(result[1].shape.width).toBeCloseTo(0.01, 4);
+    expect(result[1].fwhm).toBeCloseTo(0.01, 4);
 
     expect(result[2].x).toBeCloseTo(73.932, 1);
     expect(result[2].y).toBeCloseTo((10.2373 * max) / 100, 2);
-    expect(result[2].shape.width).toBeCloseTo(0.01, 4);
+    expect(result[2].fwhm).toBeCloseTo(0.01, 4);
 
     expect(result[3].x).toBeCloseTo(157.837, 1);
     expect(result[3].y).toBeCloseTo((51.39931 * max) / 100, 2);
-    expect(result[3].shape.width).toBeCloseTo(0.01, 4);
+    expect(result[3].fwhm).toBeCloseTo(0.01, 4);
 
     expect(result[4].x).toBeCloseTo(159.835, 1);
     expect(result[4].y).toBeCloseTo(max, 2);
-    expect(result[4].shape.width).toBeCloseTo(0.01, 4);
+    expect(result[4].fwhm).toBeCloseTo(0.01, 4);
 
     expect(result[5].x).toBeCloseTo(161.833, 1);
     expect(result[5].y).toBeCloseTo((48.63878 * max) / 100, 2);
-    expect(result[5].shape.width).toBeCloseTo(0.01, 4);
+    expect(result[5].fwhm).toBeCloseTo(0.01, 4);
   });
 });

--- a/src/__tests__/simple.test.ts
+++ b/src/__tests__/simple.test.ts
@@ -26,7 +26,7 @@ describe('Simple test cases', () => {
     negY.push(0);
   }
 
-  let widthToFWHM = getShape1D('gaussian').widthToFWHM;
+  let widthToFWHM = getShape1D({ kind: 'gaussian' }).widthToFWHM;
 
   it('gsd not realtop', () => {
     let peaks = gsd(
@@ -42,7 +42,6 @@ describe('Simple test cases', () => {
     );
 
     expect(peaks[0].y).toBeCloseTo(4.657, 3);
-    expect(peaks[0].shape.noiseLevel).toBeCloseTo(1.1956, 3);
     expect(peaks[0].x).toBeCloseTo(15, 2);
   });
 
@@ -60,7 +59,6 @@ describe('Simple test cases', () => {
       },
     );
     expect(peaks[0].y).toBeCloseTo(-4.657, 3);
-    expect(peaks[0].shape.noiseLevel).toBeCloseTo(1.1956, 3);
     expect(peaks[0].x).toBeCloseTo(15, 2);
   });
 
@@ -82,13 +80,11 @@ describe('Simple test cases', () => {
     expect(peaks).toMatchCloseTo(
       [
         {
-          shape: {
-            noiseLevel: 1.2434539324230613,
-            soft: false,
-            width: widthToFWHM(3),
-          },
+          width: 3,
+          fwhm: widthToFWHM(3),
           x: 15,
           y: 5,
+          shape: { kind: 'gaussian' },
         },
       ],
       2,
@@ -112,13 +108,11 @@ describe('Simple test cases', () => {
     expect(peaks).toMatchCloseTo(
       [
         {
-          shape: {
-            noiseLevel: 1.2434539324230613,
-            soft: false,
-            width: widthToFWHM(3),
-          },
+          width: 3,
+          fwhm: widthToFWHM(3),
           x: 14.5,
           y: 4.006546067576939,
+          shape: { kind: 'gaussian' },
         },
       ],
       2,

--- a/src/__tests__/simpleShifted.test.ts
+++ b/src/__tests__/simpleShifted.test.ts
@@ -38,16 +38,14 @@ describe('Simple shifted baseline test cases', () => {
         },
       },
     );
-    let widthToFWHM = getShape1D('gaussian').widthToFWHM;
+    let widthToFWHM = getShape1D({ kind: 'gaussian' }).widthToFWHM;
     expect(peaks).toHaveLength(1);
     expect(peaks[0]).toMatchCloseTo({
       x: 15,
       y: 4.657142857142857,
-      shape: {
-        width: widthToFWHM(2),
-        soft: false,
-        noiseLevel: 0.6695521174585716,
-      },
+      width: 2,
+      fwhm: widthToFWHM(2),
+      shape: { kind: 'gaussian' },
     });
   });
 
@@ -64,16 +62,14 @@ describe('Simple shifted baseline test cases', () => {
         },
       },
     );
-    let widthToFWHM = getShape1D('gaussian').widthToFWHM;
+    let widthToFWHM = getShape1D({ kind: 'gaussian' }).widthToFWHM;
     expect(peaks).toHaveLength(1);
     expect(peaks[0]).toMatchCloseTo({
       x: 15,
       y: -4.657142857142857,
-      shape: {
-        width: widthToFWHM(2),
-        soft: false,
-        noiseLevel: 0.6695521174585716,
-      },
+      width: 2,
+      fwhm: widthToFWHM(2),
+      shape: { kind: 'gaussian' },
     });
   });
 });

--- a/src/__tests__/simulated.test.ts
+++ b/src/__tests__/simulated.test.ts
@@ -1,5 +1,6 @@
-import { gsd, optimizePeaks } from '..';
 import type { DataXY } from 'cheminfo-types';
+
+import { gsd, optimizePeaks } from '..';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { generateSpectrum } = require('spectrum-generator');

--- a/src/__tests__/simulated.test.ts
+++ b/src/__tests__/simulated.test.ts
@@ -1,4 +1,5 @@
-import { DataType, gsd, optimizePeaks } from '..';
+import { gsd, optimizePeaks } from '..';
+import type { DataXY } from 'cheminfo-types';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { generateSpectrum } = require('spectrum-generator');
@@ -6,11 +7,11 @@ const { generateSpectrum } = require('spectrum-generator');
 describe('Global spectra deconvolution with simulated spectra', () => {
   it('Overlapping peaks', () => {
     const peaks = [
-      { x: -0.1, y: 0.2, width: 0.03 },
-      { x: 0.1, y: 0.2, width: 0.01 },
+      { x: -0.1, y: 0.2, fwhm: 0.03 },
+      { x: 0.1, y: 0.2, fwhm: 0.01 },
     ];
 
-    const data: DataType = generateSpectrum(peaks, {
+    const data: DataXY = generateSpectrum(peaks, {
       generator: {
         from: -1,
         to: 1,
@@ -26,33 +27,33 @@ describe('Global spectra deconvolution with simulated spectra', () => {
       realTopDetection: false,
       smoothY: false,
       heightFactor: 1,
-      shape: { kind: 'gaussian', width: 0 },
+      shape: { kind: 'gaussian' },
     });
 
     let optimizedPeaks = optimizePeaks(data, peakList);
 
     expect(peakList[0].x).toBeCloseTo(-0.1, 2);
     expect(peakList[0].y).toBeCloseTo(0.2, 2);
-    expect(peakList[0].shape.width).toBeCloseTo(0.03, 2);
+    expect(peakList[0].fwhm).toBeCloseTo(0.03, 2);
     expect(peakList[1].x).toBeCloseTo(0.1, 2);
     expect(peakList[1].y).toBeCloseTo(0.2, 2);
-    expect(peakList[1].shape.width).toBeCloseTo(0.01, 2);
+    expect(peakList[1].fwhm).toBeCloseTo(0.01, 2);
 
     expect(optimizedPeaks[0].x).toBeCloseTo(-0.1, 2);
     expect(optimizedPeaks[0].y).toBeCloseTo(0.2, 2);
-    expect(optimizedPeaks[0].shape.width).toBeCloseTo(0.03, 2);
+    expect(optimizedPeaks[0].fwhm).toBeCloseTo(0.03, 2);
     expect(optimizedPeaks[1].x).toBeCloseTo(0.1, 2);
     expect(optimizedPeaks[1].y).toBeCloseTo(0.2, 2);
-    expect(optimizedPeaks[1].shape.width).toBeCloseTo(0.01, 2);
+    expect(optimizedPeaks[1].fwhm).toBeCloseTo(0.01, 2);
   });
 
   it('Check gaussian shapes with shape specification', () => {
     const peaks = [
-      { x: -0.5, y: 1, width: 0.2 },
-      { x: 0.5, y: 1, width: 0.1 },
+      { x: -0.5, y: 1, fwhm: 0.2 },
+      { x: 0.5, y: 1, fwhm: 0.1 },
     ];
 
-    const data: DataType = generateSpectrum(peaks, {
+    const data: DataXY = generateSpectrum(peaks, {
       generator: { from: -1, to: 1, nbPoints: 10001 },
     });
 
@@ -61,37 +62,36 @@ describe('Global spectra deconvolution with simulated spectra', () => {
       realTopDetection: false,
       smoothY: false,
       heightFactor: 1,
-      shape: { kind: 'gaussian', width: 0 },
+      shape: { kind: 'gaussian' },
     });
 
     expect(peakList[0].x).toBeCloseTo(-0.5, 2);
     expect(peakList[0].y).toBeCloseTo(1, 2);
-    expect(peakList[0].shape.width).toBeCloseTo(0.2, 2); // inflection points in gaussian are higher tha FWHM
+    expect(peakList[0].fwhm).toBeCloseTo(0.2, 2); // inflection points in gaussian are higher tha FWHM
     expect(peakList[1].x).toBeCloseTo(0.5, 2);
     expect(peakList[1].y).toBeCloseTo(1, 2);
-    expect(peakList[1].shape.width).toBeCloseTo(0.1, 2);
+    expect(peakList[1].fwhm).toBeCloseTo(0.1, 2);
 
     let optimizedPeaks = optimizePeaks(data, peakList);
 
     expect(optimizedPeaks[0].x).toBeCloseTo(-0.5, 2);
     expect(optimizedPeaks[0].y).toBeCloseTo(1, 2);
-    expect(optimizedPeaks[0].shape.width).toBeCloseTo(0.2, 2); // optimization by default expect a gaussian shape
+    expect(optimizedPeaks[0].fwhm).toBeCloseTo(0.2, 2); // optimization by default expect a gaussian shape
     expect(optimizedPeaks[1].x).toBeCloseTo(0.5, 2);
     expect(optimizedPeaks[1].y).toBeCloseTo(1, 2);
-    expect(optimizedPeaks[1].shape.width).toBeCloseTo(0.1, 2);
+    expect(optimizedPeaks[1].fwhm).toBeCloseTo(0.1, 2);
   });
 
   it('Should provide 1 peak', () => {
-    const peaks = [{ x: 0, y: 1, width: 0.12 }];
+    const peaks = [{ x: 0, y: 1, fwhm: 0.12 }];
 
-    const data: DataType = generateSpectrum(peaks, {
+    const data: DataXY = generateSpectrum(peaks, {
       generator: {
         from: -0.5,
         to: 0.5,
         nbPoints: 10001,
         shape: {
           kind: 'gaussian',
-          width: 0,
         },
       },
     });
@@ -101,12 +101,12 @@ describe('Global spectra deconvolution with simulated spectra', () => {
       realTopDetection: false,
       smoothY: false,
       heightFactor: 1,
-      shape: { kind: 'gaussian', width: 0 },
+      shape: { kind: 'gaussian' },
     });
 
     expect(peakList).toHaveLength(1);
     expect(peakList[0].x).toBeCloseTo(0, 2);
     expect(peakList[0].y).toBeCloseTo(1, 2);
-    expect(peakList[0].shape.width).toBeCloseTo(0.12, 3);
+    expect(peakList[0].fwhm).toBeCloseTo(0.12, 3);
   });
 });

--- a/src/__tests__/ubiquitin.test.ts
+++ b/src/__tests__/ubiquitin.test.ts
@@ -1,15 +1,15 @@
 import { readFileSync } from 'fs';
 
 import { parseXY } from 'xy-parser';
-
-import { DataType, gsd } from '../gsd';
+import type { DataXY } from 'cheminfo-types';
+import { gsd } from '../gsd';
 
 // var gsd = require("../src/index");
 // var optimizePeaks = require("../src/optimize");
 
 describe('Global spectra deconvolution ubiquitin', () => {
   it('HR mass spectra', () => {
-    let spectrum: DataType = parseXY(
+    let spectrum: DataXY = parseXY(
       readFileSync(`${__dirname}/data/ubiquitin.txt`, 'utf-8'),
     );
     // var d = new Date();
@@ -22,7 +22,6 @@ describe('Global spectra deconvolution ubiquitin', () => {
     let result = gsd(spectrum, {
       noiseLevel: noiseLevel,
       minMaxRatio: 0.0,
-      broadRatio: 0,
       smoothY: false,
       realTopDetection: true,
       sgOptions: { windowSize: 7, polynomial: 3 },

--- a/src/__tests__/ubiquitin.test.ts
+++ b/src/__tests__/ubiquitin.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from 'fs';
 
-import { parseXY } from 'xy-parser';
 import type { DataXY } from 'cheminfo-types';
+import { parseXY } from 'xy-parser';
+
 import { gsd } from '../gsd';
 
 // var gsd = require("../src/index");

--- a/src/gsd.ts
+++ b/src/gsd.ts
@@ -1,5 +1,5 @@
-import { getShape1D, Shape1D } from 'ml-peak-shape-generator';
 import type { DataXY, DoubleArray } from 'cheminfo-types';
+import { getShape1D, Shape1D } from 'ml-peak-shape-generator';
 import SG from 'ml-savitzky-golay-generalized';
 /**
  * Global spectra deconvolution
@@ -153,7 +153,6 @@ export function gsd(data: DataXY, options: GSDOptions = {}): Peak1D[] {
   let minddY: number[] = [];
   let intervalL: LastType[] = [];
   let intervalR: LastType[] = [];
-  let broadMask: boolean[] = [];
 
   // By the intermediate value theorem We cannot find 2 consecutive maximum or minimum
   for (let i = 1; i < yData.length - 1; ++i) {
@@ -205,8 +204,9 @@ export function gsd(data: DataXY, options: GSDOptions = {}): Peak1D[] {
     distanceJ: number,
     minDistance: number,
     gettingCloser: boolean;
-  for (let j = 0; j < minddY.length; ++j) {
-    frequency = xData[minddY[j]];
+
+  for (const minddYIndex of minddY) {
+    frequency = xData[minddYIndex];
     possible = -1;
     let k = lastK + 1;
     minDistance = Number.MAX_VALUE;
@@ -229,14 +229,14 @@ export function gsd(data: DataXY, options: GSDOptions = {}): Peak1D[] {
     }
 
     if (possible !== -1) {
-      if (Math.abs(yData[minddY[j]]) > minMaxRatio * maxY) {
+      if (Math.abs(yData[minddYIndex]) > minMaxRatio * maxY) {
         let width = Math.abs(intervalR[possible].x - intervalL[possible].x);
         signals.push({
-          index: minddY[j],
+          index: minddYIndex,
           x: frequency,
           y: maxCriteria
-            ? yData[minddY[j]] + noiseLevel
-            : -yData[minddY[j]] - noiseLevel,
+            ? yData[minddYIndex] + noiseLevel
+            : -yData[minddYIndex] - noiseLevel,
           width: width,
           fwhm: widthProcessor(width),
           shape,

--- a/src/post/__tests__/broadenPeaks.test.ts
+++ b/src/post/__tests__/broadenPeaks.test.ts
@@ -11,17 +11,17 @@ describe('broadenPeaks', () => {
       {
         x: 5,
         y: 10,
-        width: 7.5
+        width: 7.5,
       },
       {
         x: 10,
         y: 10,
-        width: 7.5
+        width: 7.5,
       },
       {
         x: 30,
         y: 10,
-        width: 10
+        width: 10,
       },
     ]);
   });

--- a/src/post/__tests__/broadenPeaks.test.ts
+++ b/src/post/__tests__/broadenPeaks.test.ts
@@ -3,31 +3,25 @@ import { broadenPeaks } from '../broadenPeaks';
 describe('broadenPeaks', () => {
   it('should prevent overlap', () => {
     let result = broadenPeaks([
-      { x: 5, y: 10, shape: { width: 5 } },
-      { x: 10, y: 10, shape: { width: 5 } },
-      { x: 30, y: 10, shape: { width: 5 } },
+      { x: 5, y: 10, width: 5 },
+      { x: 10, y: 10, width: 5 },
+      { x: 30, y: 10, width: 5 },
     ]);
     expect(result).toStrictEqual([
       {
         x: 5,
         y: 10,
-        shape: {
-          width: 7.5,
-        },
+        width: 7.5
       },
       {
         x: 10,
         y: 10,
-        shape: {
-          width: 7.5,
-        },
+        width: 7.5
       },
       {
         x: 30,
         y: 10,
-        shape: {
-          width: 10,
-        },
+        width: 10
       },
     ]);
   });
@@ -35,64 +29,64 @@ describe('broadenPeaks', () => {
   it('should prevent overlap with factor=1', () => {
     let result = broadenPeaks(
       [
-        { x: 5, y: 10, shape: { width: 10 } },
-        { x: 10, y: 10, shape: { width: 10 } },
-        { x: 30, y: 10, shape: { width: 10 } },
+        { x: 5, y: 10, width: 10 },
+        { x: 10, y: 10, width: 10 },
+        { x: 30, y: 10, width: 10 },
       ],
       { factor: 1 },
     );
     expect(result).toStrictEqual([
-      { shape: { width: 7.5 }, x: 5, y: 10 },
-      { shape: { width: 7.5 }, x: 10, y: 10 },
-      { shape: { width: 10 }, x: 30, y: 10 },
+      { width: 7.5, x: 5, y: 10 },
+      { width: 7.5, x: 10, y: 10 },
+      { width: 10, x: 30, y: 10 },
     ]);
   });
 
   it('should prevent overlap with factor=3', () => {
     let result = broadenPeaks(
       [
-        { x: 5, y: 10, shape: { width: 10 } },
-        { x: 10, y: 10, shape: { width: 10 } },
-        { x: 30, y: 10, shape: { width: 10 } },
+        { x: 5, y: 10, width: 10 },
+        { x: 10, y: 10, width: 10 },
+        { x: 30, y: 10, width: 10 },
       ],
       { factor: 3 },
     );
     expect(result).toStrictEqual([
-      { shape: { width: 17.5 }, x: 5, y: 10 },
-      { shape: { width: 12.5 }, x: 10, y: 10 },
-      { shape: { width: 25 }, x: 30, y: 10 },
+      { width: 17.5, x: 5, y: 10 },
+      { width: 12.5, x: 10, y: 10 },
+      { width: 25, x: 30, y: 10 },
     ]);
   });
 
   it('should prevent overlap but small factor', () => {
     let result = broadenPeaks(
       [
-        { x: 5, y: 10, shape: { width: 5 } },
-        { x: 10, y: 10, shape: { width: 5 } },
-        { x: 30, y: 10, shape: { width: 5 } },
+        { x: 5, y: 10, width: 5 },
+        { x: 10, y: 10, width: 5 },
+        { x: 30, y: 10, width: 5 },
       ],
       { factor: 0.5 },
     );
     expect(result).toStrictEqual([
-      { shape: { width: 2.5 }, x: 5, y: 10 },
-      { shape: { width: 2.5 }, x: 10, y: 10 },
-      { shape: { width: 2.5 }, x: 30, y: 10 },
+      { width: 2.5, x: 5, y: 10 },
+      { width: 2.5, x: 10, y: 10 },
+      { width: 2.5, x: 30, y: 10 },
     ]);
   });
 
   it('should allow overlap', () => {
     let result = broadenPeaks(
       [
-        { x: 5, y: 10, shape: { width: 5 } },
-        { x: 10, y: 10, shape: { width: 5 } },
-        { x: 30, y: 10, shape: { width: 5 } },
+        { x: 5, y: 10, width: 5 },
+        { x: 10, y: 10, width: 5 },
+        { x: 30, y: 10, width: 5 },
       ],
       { overlap: true },
     );
     expect(result).toStrictEqual([
-      { shape: { width: 10 }, x: 5, y: 10 },
-      { shape: { width: 10 }, x: 10, y: 10 },
-      { shape: { width: 10 }, x: 30, y: 10 },
+      { width: 10, x: 5, y: 10 },
+      { width: 10, x: 10, y: 10 },
+      { width: 10, x: 30, y: 10 },
     ]);
   });
 });

--- a/src/post/__tests__/groupPeaks.test.ts
+++ b/src/post/__tests__/groupPeaks.test.ts
@@ -3,67 +3,67 @@ import { groupPeaks } from '../groupPeaks';
 describe('groupPeaks', () => {
   it('default factor value', () => {
     let result = groupPeaks([
-      { x: 5, y: 10, shape: { width: 5 } },
-      { x: 10, y: 10, shape: { width: 5 } },
-      { x: 30, y: 10, shape: { width: 5 } },
+      { x: 5, y: 10, width: 5 },
+      { x: 10, y: 10, width: 5 },
+      { x: 30, y: 10, width: 5 },
     ]);
     expect(result).toStrictEqual([
       [
-        { x: 5, y: 10, shape: { width: 5 } },
-        { x: 10, y: 10, shape: { width: 5 } },
+        { x: 5, y: 10, width: 5 },
+        { x: 10, y: 10, width: 5 },
       ],
-      [{ x: 30, y: 10, shape: { width: 5 } }],
+      [{ x: 30, y: 10, width: 5 }],
     ]);
   });
 
   it('factor = 0.1', () => {
     let result = groupPeaks(
       [
-        { x: 5, y: 10, shape: { width: 5 } },
-        { x: 10, y: 10, shape: { width: 5 } },
-        { x: 30, y: 10, shape: { width: 5 } },
+        { x: 5, y: 10, width: 5 },
+        { x: 10, y: 10, width: 5 },
+        { x: 30, y: 10, width: 5 },
       ],
       0.1,
     );
     expect(result).toStrictEqual([
-      [{ x: 5, y: 10, shape: { width: 5 } }],
-      [{ x: 10, y: 10, shape: { width: 5 } }],
-      [{ x: 30, y: 10, shape: { width: 5 } }],
+      [{ x: 5, y: 10, width: 5 }],
+      [{ x: 10, y: 10, width: 5 }],
+      [{ x: 30, y: 10, width: 5 }],
     ]);
   });
 
   it('factor=3', () => {
     let result = groupPeaks(
       [
-        { x: 5, y: 10, shape: { width: 5 } },
-        { x: 10, y: 10, shape: { width: 5 } },
-        { x: 30, y: 10, shape: { width: 5 } },
+        { x: 5, y: 10, width: 5 },
+        { x: 10, y: 10, width: 5 },
+        { x: 30, y: 10, width: 5 },
       ],
       3,
     );
     expect(result).toStrictEqual([
       [
-        { x: 5, y: 10, shape: { width: 5 } },
-        { x: 10, y: 10, shape: { width: 5 } },
+        { x: 5, y: 10, width: 5 },
+        { x: 10, y: 10, width: 5 },
       ],
-      [{ x: 30, y: 10, shape: { width: 5 } }],
+      [{ x: 30, y: 10, width: 5 }],
     ]);
   });
 
   it('factor=5', () => {
     let result = groupPeaks(
       [
-        { x: 5, y: 10, shape: { width: 5 } },
-        { x: 10, y: 10, shape: { width: 5 } },
-        { x: 30, y: 10, shape: { width: 5 } },
+        { x: 5, y: 10, width: 5 },
+        { x: 10, y: 10, width: 5 },
+        { x: 30, y: 10, width: 5 },
       ],
       5,
     );
     expect(result).toStrictEqual([
       [
-        { x: 5, y: 10, shape: { width: 5 } },
-        { x: 10, y: 10, shape: { width: 5 } },
-        { x: 30, y: 10, shape: { width: 5 } },
+        { x: 5, y: 10, width: 5 },
+        { x: 10, y: 10, width: 5 },
+        { x: 30, y: 10, width: 5 },
       ],
     ]);
   });

--- a/src/post/__tests__/optimizePeaks.test.ts
+++ b/src/post/__tests__/optimizePeaks.test.ts
@@ -1,7 +1,7 @@
 import { toMatchCloseTo } from 'jest-matcher-deep-close-to';
 import { generateSpectrum } from 'spectrum-generator';
 
-import { DataType } from '../../gsd';
+import { DataXY } from 'cheminfo-types';
 import { optimizePeaks } from '../optimizePeaks';
 
 expect.extend({ toMatchCloseTo });
@@ -19,17 +19,18 @@ describe('optimizePeaks', () => {
           kind: 'gaussian',
         },
       },
-    }) as DataType;
+    }) as DataXY;
 
     let result = optimizePeaks(data, [
-      { x: 0.01, y: 0.9, shape: { width: 0.11 } },
+      { x: 0.01, y: 0.9, width: 0.11 },
     ]);
     expect(result).toMatchCloseTo([
       {
         x: -3.419674049814014e-8,
         y: 0.999994064595118,
+        fwhm: 0.12000070163648587,
         shape: {
-          width: 0.12000070163648587,
+          kind: 'gaussian'
         },
       },
     ]);
@@ -45,7 +46,7 @@ describe('optimizePeaks', () => {
     expect(() =>
       optimizePeaks(
         data,
-        [{ x: 0.1, y: 0.9, shape: { width: 0.11 } }],
+        [{ x: 0.1, y: 0.9, width: 0.11 }],
         options,
       ),
     ).toThrow('The execution time is over to 0 seconds');

--- a/src/post/__tests__/optimizePeaks.test.ts
+++ b/src/post/__tests__/optimizePeaks.test.ts
@@ -1,7 +1,7 @@
+import { DataXY } from 'cheminfo-types';
 import { toMatchCloseTo } from 'jest-matcher-deep-close-to';
 import { generateSpectrum } from 'spectrum-generator';
 
-import { DataXY } from 'cheminfo-types';
 import { optimizePeaks } from '../optimizePeaks';
 
 expect.extend({ toMatchCloseTo });
@@ -21,16 +21,14 @@ describe('optimizePeaks', () => {
       },
     }) as DataXY;
 
-    let result = optimizePeaks(data, [
-      { x: 0.01, y: 0.9, width: 0.11 },
-    ]);
+    let result = optimizePeaks(data, [{ x: 0.01, y: 0.9, width: 0.11 }]);
     expect(result).toMatchCloseTo([
       {
         x: -3.419674049814014e-8,
         y: 0.999994064595118,
         fwhm: 0.12000070163648587,
         shape: {
-          kind: 'gaussian'
+          kind: 'gaussian',
         },
       },
     ]);
@@ -44,11 +42,7 @@ describe('optimizePeaks', () => {
       },
     };
     expect(() =>
-      optimizePeaks(
-        data,
-        [{ x: 0.1, y: 0.9, width: 0.11 }],
-        options,
-      ),
+      optimizePeaks(data, [{ x: 0.1, y: 0.9, width: 0.11 }], options),
     ).toThrow('The execution time is over to 0 seconds');
   });
 });

--- a/src/post/__tests__/optimizePeaks.test.ts
+++ b/src/post/__tests__/optimizePeaks.test.ts
@@ -1,4 +1,3 @@
-import { DataXY } from 'cheminfo-types';
 import { toMatchCloseTo } from 'jest-matcher-deep-close-to';
 import { generateSpectrum } from 'spectrum-generator';
 
@@ -19,7 +18,7 @@ describe('optimizePeaks', () => {
           kind: 'gaussian',
         },
       },
-    }) as DataXY;
+    });
 
     let result = optimizePeaks(data, [{ x: 0.01, y: 0.9, width: 0.11 }]);
     expect(result).toMatchCloseTo([

--- a/src/post/broadenPeaks.ts
+++ b/src/post/broadenPeaks.ts
@@ -38,15 +38,14 @@ export function broadenPeaks(
     for (let i = 0; i < peaks.length - 1; i++) {
       let peak = peaks[i];
       let nextPeak = peaks[i + 1];
-      if ((peak.to as number) > (nextPeak.from as number)) {
-        peak.to = nextPeak.from =
-          ((peak.to as number) + (nextPeak.from as number)) / 2;
+      if (peak.to > nextPeak.from) {
+        peak.to = nextPeak.from = (peak.to + nextPeak.from) / 2;
       }
     }
   }
 
   for (let peak of peaks) {
-    peak.width = (peak.to as number) - (peak.from as number);
+    peak.width = peak.to - peak.from;
   }
 
   return peaks.map((peak: Peak1D) => {

--- a/src/post/broadenPeaks.ts
+++ b/src/post/broadenPeaks.ts
@@ -1,29 +1,37 @@
-import { PeakType } from '../gsd';
+import type { Peak1D } from '../gsd';
 
 /**
  * This method will allow to enlarge peaks and prevent overlap between peaks
  * Because peaks may not be symmetric after we add 2 properties, from and to.
- * @param {Array} peakList
- * @param {object} [options={}]
- * @param {number} [options.factor=2]
- * @param {boolean} [options.overlap=false] by default we don't allow overlap
  * @return {Array} peakList
  */
-interface OptionsType {
+interface BroadenPeaksOptions {
+  /**
+   * @default 2
+   */
   factor?: number;
+  /**
+   * by default we don't allow overlap
+   * @default false
+   */
   overlap?: boolean;
 }
-export function broadenPeaks(
-  peakList: PeakType[],
-  options: OptionsType = {},
-): PeakType[] {
-  const { factor = 2, overlap = false }: OptionsType = options;
 
-  const peaks: PeakType[] = JSON.parse(JSON.stringify(peakList));
+interface InternPeak1D extends Peak1D {
+  from: number;
+  to: number;
+}
+export function broadenPeaks(
+  peakList: Peak1D[],
+  options: BroadenPeaksOptions = {},
+): Peak1D[] {
+  const { factor = 2, overlap = false } = options;
+
+  const peaks: InternPeak1D[] = JSON.parse(JSON.stringify(peakList));
 
   peaks.forEach((peak) => {
-    peak.from = peak.x - (peak.shape.width / 2) * factor;
-    peak.to = peak.x + (peak.shape.width / 2) * factor;
+    peak.from = peak.x - (peak.width / 2) * factor;
+    peak.to = peak.x + (peak.width / 2) * factor;
   });
 
   if (!overlap) {
@@ -38,11 +46,13 @@ export function broadenPeaks(
   }
 
   for (let peak of peaks) {
-    peak.shape.width = (peak.to as number) - (peak.from as number);
+    peak.width = (peak.to as number) - (peak.from as number);
   }
 
-  return peaks.map((peak: PeakType): PeakType => {
-    const { x, y, shape }: PeakType = peak;
-    return { x, y, shape } as PeakType;
+  return peaks.map((peak: Peak1D) => {
+    const { x, y, width, shape } = peak;
+    const peakResult: Peak1D = { x, y, width };
+    if (shape) peakResult.shape = shape;
+    return peakResult;
   });
 }

--- a/src/post/groupPeaks.ts
+++ b/src/post/groupPeaks.ts
@@ -1,29 +1,31 @@
+import type { Peak1D } from '../gsd';
+
 /**
  * Group peaks based on factor and add group property in peaks
- * @param {array} peakList
- * @param {number} factor
  */
 
-import { PeakType } from '..';
+export interface GroupPeaksOptions {
+  factor?: number;
+  width?: number;
+}
 
-export function groupPeaks(peakList: PeakType[], factor = 1): PeakType[][] {
+export function groupPeaks(peakList: Peak1D[], factor = 1): Peak1D[][] {
   if (peakList && peakList.length === 0) return [];
 
-  let peaks: PeakType[] = JSON.parse(JSON.stringify(peakList));
+  let peaks: Peak1D[] = JSON.parse(JSON.stringify(peakList));
   peaks.sort((a, b) => a.x - b.x);
 
-  let previousPeak: PeakType = {
+  let previousPeak: Peak1D = {
     x: Number.NEGATIVE_INFINITY,
-    shape: { width: 1 },
     y: 0,
+    width: 1,
   };
-  let currentGroup: PeakType[] = [previousPeak];
-  let groups: PeakType[][] = [];
+  let currentGroup: Peak1D[] = [previousPeak];
+  let groups: Peak1D[][] = [];
 
   peaks.forEach((peak) => {
     if (
-      (peak.x - previousPeak.x) /
-        (peak.shape.width + previousPeak.shape.width) <=
+      (peak.x - previousPeak.x) / (peak.width + previousPeak.width) <=
       factor / 2
     ) {
       currentGroup.push(peak);

--- a/src/post/joinBroadPeaks.ts
+++ b/src/post/joinBroadPeaks.ts
@@ -1,11 +1,10 @@
-import { optimize } from 'ml-spectra-fitting';
-import type { Shape1D } from 'ml-peak-shape-generator';
-import type { Peak1D } from '../gsd';
 import type { DataXY } from 'cheminfo-types';
-
+import type { Shape1D } from 'ml-peak-shape-generator';
+import SG from 'ml-savitzky-golay-generalized';
+import { optimize } from 'ml-spectra-fitting';
 import { xFindClosestIndex } from 'ml-spectra-processing';
 
-import SG from 'ml-savitzky-golay-generalized';
+import type { Peak1D } from '../gsd';
 
 /**
  * This function try to join the peaks that seems to belong to a broad signal in a single broad peak.
@@ -32,7 +31,7 @@ interface OptionsType extends Partial<GetSoftMaskOptions> {
   width?: number;
   shape?: Shape1D;
   optimization?: { kind: string; timeout: number };
-  mask?: Boolean[];
+  mask?: boolean[];
 }
 
 export function joinBroadPeaks(
@@ -150,8 +149,8 @@ function getSoftMask(
   });
 
   let maxDdy = 0;
-  for (let i = 0; i < ddY.length; i++) {
-    if (Math.abs(ddY[i]) > maxDdy) maxDdy = Math.abs(ddY[i]);
+  for (const ddYIndex of ddY) {
+    if (Math.abs(ddYIndex) > maxDdy) maxDdy = Math.abs(ddYIndex);
   }
 
   const broadMask: boolean[] = [];

--- a/src/post/optimizePeaks.ts
+++ b/src/post/optimizePeaks.ts
@@ -1,12 +1,12 @@
+import type { DataXY } from 'cheminfo-types';
+import type { Shape1D } from 'ml-peak-shape-generator';
+import { getShape1D } from 'ml-peak-shape-generator';
 import { optimize } from 'ml-spectra-fitting';
 import { xGetFromToIndex } from 'ml-spectra-processing';
 
 import type { Peak1D } from '../gsd';
-import type { Shape1D } from 'ml-peak-shape-generator';
-import type { DataXY } from 'cheminfo-types';
 
 import { groupPeaks } from './groupPeaks';
-import { getShape1D } from 'ml-peak-shape-generator';
 
 /**
  * Optimize the position (x), max intensity (y), full width at half maximum (width)

--- a/src/post/optimizePeaks.ts
+++ b/src/post/optimizePeaks.ts
@@ -11,26 +11,41 @@ import { groupPeaks } from './groupPeaks';
 /**
  * Optimize the position (x), max intensity (y), full width at half maximum (width)
  * and the ratio of gaussian contribution (mu) if it's required. It supports three kind of shapes: gaussian, lorentzian and pseudovoigt
- * @param {object} data - An object containing the x and y data to be fitted.
- * @param {Array} peakList - A list of initial parameters to be optimized. e.g. coming from a peak picking [{x, y, width}].
- * @param {object} [options = {}] -
- * @param {number} [options.factorWidth = 1] - times of width to group peaks.
- * @param {number} [options.factorLimits = 2] - times of width to use to optimize peaks
- * @param {object} [options.shape={}] - it's specify the kind of shape used to fitting.
- * @param {string} [options.shape.kind='gaussian'] - kind of shape; lorentzian, gaussian and pseudovoigt are supported.
- * @param {string} [options.shape.options={}] - options depending the kind of shape
- * @param {object} [options.optimization={}] - it's specify the kind and options of the algorithm use to optimize parameters.
- * @param {string} [options.optimization.kind='lm'] - kind of algorithm. By default it's levenberg-marquardt.
- * @param {object} [options.optimization.options={}] - options for the specific kind of algorithm.
- * @param {number} [options.optimization.options.timeout=10] - maximum time running before break in seconds.
+ * @param data - An object containing the x and y data to be fitted.
+ * @param peakList - A list of initial parameters to be optimized. e.g. coming from a peak picking [{x, y, width}].
  */
 interface OptimizePeaksOptions {
+  /**
+   * times of width to group peaks.
+   * @default 1
+   */
   factorWidth?: number;
+  /**
+   * times of width to use to optimize peaks
+   * @default 2
+   */
   factorLimits?: number;
+  /**
+   * it's specify the kind of shape used to fitting.
+   */
   shape?: Shape1D;
+  /**
+   * it's specify the kind and options of the algorithm use to optimize parameters.
+   */
   optimization?: {
+    /**
+     * kind of algorithm. By default it's levenberg-marquardt.
+     * @default 'lm'
+     */
     kind: string;
+    /**
+     * options for the specific kind of algorithm.
+     */
     options: {
+      /**
+       * maximum time running before break in seconds.
+       * @default 10
+       */
       timeout: number;
     };
   };


### PR DESCRIPTION
use Peak1D interface and Shape1D in the peak structure
remove properties from output soft, noiseLevel, fromTo
check the peak list to homogenize fwhm n width in optimizePeaks
generate the soft mask in joinBroadPeaks
use types from cheminfo-types
update ml-peak-shape-generator to 3.0.1