### PR TITLE
chore: align tooling with current cheminfo standards

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 src/__tests__/data/*.json
 CHANGELOG.md
+coverage
 lib
 examples

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Global spectral deconvolution and peak optimizer.
 
-## [API documentation](http://mljs.github.io/global-spectral-deconvolution/)
+## [API documentation](https://mljs.github.io/global-spectral-deconvolution/)
 
 `gsd`is using an algorithm that is searching for inflection points to determine the position and width of peaks. The width is defined as the distance between the 2 inflection points. Depending the shape of the peak this width may differ from 'fwhm' (Full Width Half Maximum).
 

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "scripts": {
     "build": "npm run tsc && cheminfo-build --entry lib/index.js --root GSD",
     "check-types": "tsc --noEmit",
-    "clean": "rimraf lib",
-    "eslint": "eslint . --cache",
-    "eslint-fix": "eslint . --cache --fix",
+    "clean": "rimraf coverage lib",
+    "eslint": "eslint src",
+    "eslint-fix": "eslint src --fix",
     "prepack": "npm run tsc",
-    "prettier": "prettier --check .",
-    "prettier-write": "prettier --write .",
+    "prettier": "prettier --check src",
+    "prettier-write": "prettier --write src",
     "test": "npm run test-only && npm run check-types && npm run eslint && npm run prettier",
     "test-only": "vitest run --coverage",
     "tsc": "npm run clean && npm run tsc-build",
@@ -50,22 +50,22 @@
     "ml-peak-shape-generator": "^5.1.0",
     "ml-savitzky-golay-generalized": "^5.0.0",
     "ml-spectra-fitting": "^6.1.0",
-    "ml-spectra-processing": "^14.28.1"
+    "ml-spectra-processing": "^14.29.0"
   },
   "devDependencies": {
-    "@types/node": "^25.6.0",
-    "@vitest/coverage-v8": "^4.1.5",
+    "@types/node": "^25.9.3",
+    "@vitest/coverage-v8": "^4.1.8",
     "@zakodium/tsconfig": "^1.0.5",
     "cheminfo-build": "^1.3.2",
     "eslint": "^9.39.2",
-    "eslint-config-cheminfo-typescript": "^22.0.0",
+    "eslint-config-cheminfo-typescript": "^22.1.0",
     "jest-matcher-deep-close-to": "^3.0.2",
-    "mf-global": "^3.1.32",
-    "prettier": "^3.8.3",
+    "mf-global": "^3.1.33",
+    "prettier": "^3.8.4",
     "rimraf": "^6.1.3",
     "spectrum-generator": "^8.2.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.5",
+    "vitest": "^4.1.8",
     "xy-parser": "^6.0.1"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     coverage: {
-      include: ['src/**'],
-      exclude: ['**/__tests__/data/**', '**/.npmignore'],
+      include: ['src/**/*.ts'],
+      provider: 'v8',
     },
     setupFiles: ['vitest.setup.ts'],
     snapshotFormat: {


### PR DESCRIPTION
- standard eslint/prettier script names (eslint src, prettier --check src)
- clean removes coverage/
- vitest coverage include src/**/*.ts with explicit v8 provider
- add coverage to .prettierignore
- bump dependencies (eslint kept on 9.x)
- use https for API docs link in README
